### PR TITLE
Use placeholder text instead of setting default value.

### DIFF
--- a/vzurl/fieldtypes/VzUrlFieldType.php
+++ b/vzurl/fieldtypes/VzUrlFieldType.php
@@ -38,12 +38,6 @@ class VzUrlFieldType extends BaseFieldType
 
         $settings = $this->getSettings();
 
-        // Default to http://
-        if ( empty($value) )
-        {
-            $value = 'http://';
-        }
-
         $class  = 'vzurl-field';
         $class .= $settings->followRedirects ? ' follow-redirects' : '';
 

--- a/vzurl/templates/input.html
+++ b/vzurl/templates/input.html
@@ -5,6 +5,7 @@
     name: name,
     value: value,
     class: 'nicetext '~class,
+    placeholder: 'http://'
 } %}
 
 <div class="vzurl-wrapper">


### PR DESCRIPTION
When using the fieldtype in contexts with a mix of absolute & relative urls, it can be tedious to always select the http:// default value and remove before typing in the relative URL. So rather than set a value, we hint with the placeholder.