### PR TITLE
Fix translatability of messages connected to the URL input field

### DIFF
--- a/vzurl/fieldtypes/VzUrlFieldType.php
+++ b/vzurl/fieldtypes/VzUrlFieldType.php
@@ -41,6 +41,13 @@ class VzUrlFieldType extends BaseFieldType implements IPreviewableFieldType
         $class  = 'vzurl-field';
         $class .= $settings->followRedirects ? ' follow-redirects' : '';
 
+        craft()->templates->includeTranslations(
+            'Redirects to',
+            'This URL appears to be invalid',
+            'Update',
+            'Visit URL'
+        );
+
         return craft()->templates->render('vzurl/input', array(
             'id'    => $inputId,
             'name'  => $name,


### PR DESCRIPTION
To make the JS `Craft.t` calls pick up translations defined in the project's `craft/translations/` files, we must apparently call `includeTranslations`.

https://craftcms.com/classreference/services/TemplatesService#includeTranslations-detail