### PR TITLE
Install migration to handle Craft 2 > 3 upgrades

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * VZ URL plugin for Craft CMS 3.x
+ *
+ * A URL fieldtype with validation.
+ *
+ * @link      https://github.com/elivz
+ * @copyright Copyright (c) 2018 Eli Van Zoeren
+ */
+
+namespace elivz\vzurl\migrations;
+
+use elivz\vzurl\fields\VzUrlField;
+use craft\db\Migration;
+use craft\helpers\MigrationHelper;
+
+/**
+ * m181109_211900_craft3_upgrade migration.
+ *
+ * @author  Eli Van Zoeren
+ * @package VzUrl
+ * @since   2.1.0
+ */
+class Install extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        // Fields
+        $this->update('{{%fields}}', ['type' => VzUrlField::class], ['type' => 'VzUrl']);
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "VZ Url install migration cannot be reverted.\n";
+
+        return false;
+    }
+}


### PR DESCRIPTION
We're starting to upgrade our first Craft 2 sites to Craft 3 and our VzUrl fields aren't begin upgraded by the migration added in the last update.

That migration will only run on update, but not when the plugin is initially installed. I added the same code in an Install migration and when testing the upgrade now, it works.
